### PR TITLE
Fast text input mode

### DIFF
--- a/app/src/main/java/org/kaqui/testactivities/TextTestActivity.kt
+++ b/app/src/main/java/org/kaqui/testactivities/TextTestActivity.kt
@@ -89,8 +89,7 @@ class TextTestActivity : TestActivityBase() {
                                         filters = arrayOf(InputFilter { source, _, _, _, _, _ ->
                                             if (shouldIgnoreTextInput) {
                                                 ""
-                                            }
-                                            else {
+                                            } else {
                                                 source
                                             }
                                         })

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -65,4 +65,7 @@
     <string name="settings"><font size="30">設定</font>\nPARAMÈTRES</string>
     <string name="title_activity_main_settings">Paramètres</string>
     <string name="will_update_later">Pris en compte lorsque vous quittez les paramètres</string>
+
+    <string name="fast_text_input_title">Saisie de texte rapide</string>
+    <string name="fast_text_input_summary">Le texte sera vérifié lors de la saisie. Rapide, mais méfiez-vous des fautes de frappe!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,4 +73,7 @@
     <string name="title_activity_main_settings">Settings</string>
     <string name="enable_dark_theme">Enable dark theme</string>
     <string name="will_update_later">Will update when leaving the settings screen</string>
+
+    <string name="fast_text_input_title">Fast text input</string>
+    <string name="fast_text_input_summary">Text will be checked during input. Fast, but beware of typos!</string>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -21,4 +21,10 @@
         app:title="@string/enable_dark_theme"
         app:summary="@string/will_update_later" />
 
+    <SwitchPreferenceCompat
+        app:key="fast_text_input"
+        app:defaultValue="false"
+        app:title="@string/fast_text_input_title"
+        app:summary="@string/fast_text_input_summary" />
+
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Add option to settings to enable 'Fast text input' mode for 'hiragana/katakana to romaji writing'.
Main goal is to speed up this type of quiz by removing the need to press submit answer button.

In this mode text will be checked during user input.
After answer input is blocked for 100 or 500ms to prevent accidental keystroke.